### PR TITLE
Return T* from allocators

### DIFF
--- a/include/box2d/b2_block_allocator.h
+++ b/include/box2d/b2_block_allocator.h
@@ -43,7 +43,7 @@ public:
 
     /// Allocate memory. This will use b2Alloc if the size is larger than b2_maxBlockSize.
     template <typename T>
-    [[nodiscard]] void* Allocate(std::size_t count = 1);
+    [[nodiscard]] T* Allocate(std::size_t count = 1);
 
 
     /// Free memory. This will use b2Free if the size is larger than b2_maxBlockSize.
@@ -64,10 +64,10 @@ private:
 };
 
 template <typename T>
-void* b2BlockAllocator::Allocate(std::size_t count)
+T* b2BlockAllocator::Allocate(std::size_t count)
 {
     assert(count > 0);
-    return HandleAllocate(sizeof(T) * count);
+    return (T*)HandleAllocate(sizeof(T) * count);
 }
 
 template <typename T>

--- a/include/box2d/b2_stack_allocator.h
+++ b/include/box2d/b2_stack_allocator.h
@@ -47,7 +47,7 @@ public:
     ~b2StackAllocator();
 
     template<typename T> 
-    [[nodiscard]] void* Allocate(std::size_t count = 1); 
+    [[nodiscard]] T* Allocate(std::size_t count = 1); 
 
     template<typename T>
     void Free(T* ptr);
@@ -70,9 +70,9 @@ private:
 };
 
 template<typename T>
-void* b2StackAllocator::Allocate(std::size_t count)
+T* b2StackAllocator::Allocate(std::size_t count)
 {
-    return HandleAllocate(sizeof(T) * count);
+    return (T*)HandleAllocate(sizeof(T) * count);
 }
 
 template<typename T>

--- a/src/collision/b2_chain_shape.cpp
+++ b/src/collision/b2_chain_shape.cpp
@@ -85,7 +85,7 @@ void b2ChainShape::CreateChain(const b2Vec2* vertices, std::int32_t count, const
 
 b2Shape* b2ChainShape::Clone(b2BlockAllocator* allocator) const
 {
-    void* mem = allocator->Allocate<b2ChainShape>();
+    auto* mem = allocator->Allocate<b2ChainShape>();
     b2ChainShape* clone = new (mem) b2ChainShape;
     clone->CreateChain(m_vertices, m_count, m_prevVertex, m_nextVertex);
     return clone;

--- a/src/collision/b2_circle_shape.cpp
+++ b/src/collision/b2_circle_shape.cpp
@@ -27,7 +27,7 @@
 
 b2Shape* b2CircleShape::Clone(b2BlockAllocator* allocator) const
 {
-    void* mem = allocator->Allocate<b2CircleShape>();
+    auto* mem = allocator->Allocate<b2CircleShape>();
     b2CircleShape* clone = new (mem) b2CircleShape;
     *clone = *this;
     return clone;

--- a/src/collision/b2_edge_shape.cpp
+++ b/src/collision/b2_edge_shape.cpp
@@ -42,7 +42,7 @@ void b2EdgeShape::SetTwoSided(const b2Vec2& v1, const b2Vec2& v2)
 
 b2Shape* b2EdgeShape::Clone(b2BlockAllocator* allocator) const
 {
-    void* mem = allocator->Allocate<b2EdgeShape>();
+    auto* mem = allocator->Allocate<b2EdgeShape>();
     b2EdgeShape* clone = new (mem) b2EdgeShape;
     *clone = *this;
     return clone;

--- a/src/collision/b2_polygon_shape.cpp
+++ b/src/collision/b2_polygon_shape.cpp
@@ -27,7 +27,7 @@
 
 b2Shape* b2PolygonShape::Clone(b2BlockAllocator* allocator) const
 {
-    void* mem = allocator->Allocate<b2PolygonShape>();
+    auto* mem = allocator->Allocate<b2PolygonShape>();
     b2PolygonShape* clone = new (mem) b2PolygonShape;
     *clone = *this;
     return clone;

--- a/src/dynamics/b2_body.cpp
+++ b/src/dynamics/b2_body.cpp
@@ -172,7 +172,7 @@ b2Fixture* b2Body::CreateFixture(const b2FixtureDef* def)
 
     b2BlockAllocator* allocator = &m_world->m_blockAllocator;
 
-    void* memory = allocator->Allocate<b2Fixture>();
+    auto* memory = allocator->Allocate<b2Fixture>();
     b2Fixture* fixture = new (memory) b2Fixture;
     fixture->Create(allocator, this, def);
 

--- a/src/dynamics/b2_chain_circle_contact.cpp
+++ b/src/dynamics/b2_chain_circle_contact.cpp
@@ -30,7 +30,7 @@
 
 b2Contact* b2ChainAndCircleContact::Create(b2Fixture* fixtureA, std::int32_t indexA, b2Fixture* fixtureB, std::int32_t indexB, b2BlockAllocator* allocator)
 {
-    void* mem = allocator->Allocate<b2ChainAndCircleContact>();
+    auto* mem = allocator->Allocate<b2ChainAndCircleContact>();
     return new (mem) b2ChainAndCircleContact(fixtureA, indexA, fixtureB, indexB);
 }
 

--- a/src/dynamics/b2_chain_polygon_contact.cpp
+++ b/src/dynamics/b2_chain_polygon_contact.cpp
@@ -30,7 +30,7 @@
 
 b2Contact* b2ChainAndPolygonContact::Create(b2Fixture* fixtureA, std::int32_t indexA, b2Fixture* fixtureB, std::int32_t indexB, b2BlockAllocator* allocator)
 {
-    void* mem = allocator->Allocate<b2ChainAndPolygonContact>();
+    auto* mem = allocator->Allocate<b2ChainAndPolygonContact>();
     return new (mem) b2ChainAndPolygonContact(fixtureA, indexA, fixtureB, indexB);
 }
 

--- a/src/dynamics/b2_circle_contact.cpp
+++ b/src/dynamics/b2_circle_contact.cpp
@@ -31,7 +31,7 @@
 
 b2Contact* b2CircleContact::Create(b2Fixture* fixtureA, std::int32_t, b2Fixture* fixtureB, std::int32_t, b2BlockAllocator* allocator)
 {
-    void* mem = allocator->Allocate<b2CircleContact>();
+    auto* mem = allocator->Allocate<b2CircleContact>();
     return new (mem) b2CircleContact(fixtureA, fixtureB);
 }
 

--- a/src/dynamics/b2_contact_solver.cpp
+++ b/src/dynamics/b2_contact_solver.cpp
@@ -53,8 +53,8 @@ b2ContactSolver::b2ContactSolver(b2ContactSolverDef* def)
     m_step = def->step;
     m_allocator = def->allocator;
     m_count = def->count;
-    m_positionConstraints = (b2ContactPositionConstraint*)m_allocator->Allocate<b2ContactPositionConstraint>(m_count);
-    m_velocityConstraints = (b2ContactVelocityConstraint*)m_allocator->Allocate<b2ContactVelocityConstraint>(m_count);
+    m_positionConstraints = m_allocator->Allocate<b2ContactPositionConstraint>(m_count);
+    m_velocityConstraints = m_allocator->Allocate<b2ContactVelocityConstraint>(m_count);
     m_positions = def->positions;
     m_velocities = def->velocities;
     m_contacts = def->contacts;

--- a/src/dynamics/b2_edge_circle_contact.cpp
+++ b/src/dynamics/b2_edge_circle_contact.cpp
@@ -29,7 +29,7 @@
 
 b2Contact* b2EdgeAndCircleContact::Create(b2Fixture* fixtureA, std::int32_t, b2Fixture* fixtureB, std::int32_t, b2BlockAllocator* allocator)
 {
-    void* mem = allocator->Allocate<b2EdgeAndCircleContact>();
+    auto* mem = allocator->Allocate<b2EdgeAndCircleContact>();
     return new (mem) b2EdgeAndCircleContact(fixtureA, fixtureB);
 }
 

--- a/src/dynamics/b2_edge_polygon_contact.cpp
+++ b/src/dynamics/b2_edge_polygon_contact.cpp
@@ -29,7 +29,7 @@
 
 b2Contact* b2EdgeAndPolygonContact::Create(b2Fixture* fixtureA, std::int32_t, b2Fixture* fixtureB, std::int32_t, b2BlockAllocator* allocator)
 {
-    void* mem = allocator->Allocate<b2EdgeAndPolygonContact>();
+    auto* mem = allocator->Allocate<b2EdgeAndPolygonContact>();
     return new (mem) b2EdgeAndPolygonContact(fixtureA, fixtureB);
 }
 

--- a/src/dynamics/b2_fixture.cpp
+++ b/src/dynamics/b2_fixture.cpp
@@ -59,7 +59,7 @@ void b2Fixture::Create(b2BlockAllocator* allocator, b2Body* body, const b2Fixtur
 
     // Reserve proxy space
     std::int32_t childCount = m_shape->GetChildCount();
-    m_proxies = (b2FixtureProxy*)allocator->Allocate<b2FixtureProxy>(childCount);
+    m_proxies = allocator->Allocate<b2FixtureProxy>(childCount);
     for (std::int32_t i = 0; i < childCount; ++i)
     {
         m_proxies[i].fixture = nullptr;

--- a/src/dynamics/b2_island.cpp
+++ b/src/dynamics/b2_island.cpp
@@ -167,12 +167,12 @@ b2Island::b2Island(
     m_allocator = allocator;
     m_listener = listener;
 
-    m_bodies = (b2Body**)m_allocator->Allocate<b2Body*>(bodyCapacity);
-    m_contacts = (b2Contact**)m_allocator->Allocate<b2Contact*>(contactCapacity);
-    m_joints = (b2Joint**)m_allocator->Allocate<b2Joint*>(jointCapacity);
+    m_bodies = m_allocator->Allocate<b2Body*>(bodyCapacity);
+    m_contacts = m_allocator->Allocate<b2Contact*>(contactCapacity);
+    m_joints = m_allocator->Allocate<b2Joint*>(jointCapacity);
 
-    m_velocities = (b2Velocity*)m_allocator->Allocate<b2Velocity>(m_bodyCapacity);
-    m_positions = (b2Position*)m_allocator->Allocate<b2Position>(m_bodyCapacity);
+    m_velocities = m_allocator->Allocate<b2Velocity>(m_bodyCapacity);
+    m_positions = m_allocator->Allocate<b2Position>(m_bodyCapacity);
 }
 
 b2Island::~b2Island()

--- a/src/dynamics/b2_joint.cpp
+++ b/src/dynamics/b2_joint.cpp
@@ -95,70 +95,70 @@ b2Joint* b2Joint::Create(const b2JointDef* def, b2BlockAllocator* allocator)
     {
     case e_distanceJoint:
         {
-            void* mem = allocator->Allocate<b2DistanceJoint>();
+            auto* mem = allocator->Allocate<b2DistanceJoint>();
             joint = new (mem) b2DistanceJoint(static_cast<const b2DistanceJointDef*>(def));
         }
         break;
 
     case e_mouseJoint:
         {
-            void* mem = allocator->Allocate<b2MouseJoint>();
+            auto* mem = allocator->Allocate<b2MouseJoint>();
             joint = new (mem) b2MouseJoint(static_cast<const b2MouseJointDef*>(def));
         }
         break;
 
     case e_prismaticJoint:
         {
-            void* mem = allocator->Allocate<b2PrismaticJoint>();
+            auto* mem = allocator->Allocate<b2PrismaticJoint>();
             joint = new (mem) b2PrismaticJoint(static_cast<const b2PrismaticJointDef*>(def));
         }
         break;
 
     case e_revoluteJoint:
         {
-            void* mem = allocator->Allocate<b2RevoluteJoint>();
+            auto* mem = allocator->Allocate<b2RevoluteJoint>();
             joint = new (mem) b2RevoluteJoint(static_cast<const b2RevoluteJointDef*>(def));
         }
         break;
 
     case e_pulleyJoint:
         {
-            void* mem = allocator->Allocate<b2PulleyJoint>();
+            auto* mem = allocator->Allocate<b2PulleyJoint>();
             joint = new (mem) b2PulleyJoint(static_cast<const b2PulleyJointDef*>(def));
         }
         break;
 
     case e_gearJoint:
         {
-            void* mem = allocator->Allocate<b2GearJoint>();
+            auto* mem = allocator->Allocate<b2GearJoint>();
             joint = new (mem) b2GearJoint(static_cast<const b2GearJointDef*>(def));
         }
         break;
 
     case e_wheelJoint:
         {
-            void* mem = allocator->Allocate<b2WheelJoint>();
+            auto* mem = allocator->Allocate<b2WheelJoint>();
             joint = new (mem) b2WheelJoint(static_cast<const b2WheelJointDef*>(def));
         }
         break;
 
     case e_weldJoint:
         {
-            void* mem = allocator->Allocate<b2WeldJoint>();
+            auto* mem = allocator->Allocate<b2WeldJoint>();
             joint = new (mem) b2WeldJoint(static_cast<const b2WeldJointDef*>(def));
         }
         break;
 
     case e_frictionJoint:
         {
-            void* mem = allocator->Allocate<b2FrictionJoint>();
+            auto* mem = allocator->Allocate<b2FrictionJoint>();
             joint = new (mem) b2FrictionJoint(static_cast<const b2FrictionJointDef*>(def));
         }
         break;
 
     case e_motorJoint:
         {
-            void* mem = allocator->Allocate<b2MotorJoint>();
+            auto* mem = allocator->Allocate<b2MotorJoint>();
             joint = new (mem) b2MotorJoint(static_cast<const b2MotorJointDef*>(def));
         }
         break;

--- a/src/dynamics/b2_polygon_circle_contact.cpp
+++ b/src/dynamics/b2_polygon_circle_contact.cpp
@@ -29,7 +29,7 @@
 
 b2Contact* b2PolygonAndCircleContact::Create(b2Fixture* fixtureA, std::int32_t, b2Fixture* fixtureB, std::int32_t, b2BlockAllocator* allocator)
 {
-    void* mem = allocator->Allocate<b2PolygonAndCircleContact>();
+    auto* mem = allocator->Allocate<b2PolygonAndCircleContact>();
     return new (mem) b2PolygonAndCircleContact(fixtureA, fixtureB);
 }
 

--- a/src/dynamics/b2_polygon_contact.cpp
+++ b/src/dynamics/b2_polygon_contact.cpp
@@ -32,7 +32,7 @@
 
 b2Contact* b2PolygonContact::Create(b2Fixture* fixtureA, std::int32_t, b2Fixture* fixtureB, std::int32_t, b2BlockAllocator* allocator)
 {
-    void* mem = allocator->Allocate<b2PolygonContact>();
+    auto* mem = allocator->Allocate<b2PolygonContact>();
     return new (mem) b2PolygonContact(fixtureA, fixtureB);
 }
 

--- a/src/dynamics/b2_world.cpp
+++ b/src/dynamics/b2_world.cpp
@@ -120,7 +120,7 @@ b2Body* b2World::CreateBody(const b2BodyDef* def)
         return nullptr;
     }
 
-    void* mem = m_blockAllocator.Allocate<b2Body>();
+    auto* mem = m_blockAllocator.Allocate<b2Body>();
     b2Body* b = new (mem) b2Body(def, this);
 
     // Add to world doubly linked list.
@@ -420,7 +420,7 @@ void b2World::Solve(const b2TimeStep& step)
 
     // Build and simulate all awake islands.
     std::int32_t stackSize = m_bodyCount;
-    b2Body** stack = (b2Body**)m_stackAllocator.Allocate<b2Body*>(stackSize);
+    b2Body** stack = m_stackAllocator.Allocate<b2Body*>(stackSize);
     for (b2Body* seed = m_bodyList; seed; seed = seed->m_next)
     {
         if (seed->m_flags & b2Body::e_islandFlag)


### PR DESCRIPTION
This adds some type safety and lets us further reduce code repetition when casting the `void*` to the correct pointer type.